### PR TITLE
Add prototype gameplay example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,22 @@ if (player.pickUp(sword)) {
 player.sell(sword); // adds the item value to the player's gold
 int gold = player.getGold();
 ```
+
+## Running the prototype
+
+To try the sample game locally on macOS:
+
+1. Install a JDK (Java 8 or later) and Maven. Using Homebrew you can run:
+
+   ```bash
+   brew install maven
+   ```
+
+2. Compile and launch the game from the project directory:
+
+   ```bash
+   mvn compile
+   mvn exec:java
+   ```
+
+The game runner will start and execute `Agent1` and `Agent2` with the referee logic.

--- a/pom.xml
+++ b/pom.xml
@@ -31,4 +31,18 @@
             <version>${gamengine.version}</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>SkeletonMain</mainClass>
+                    <classpathScope>test</classpathScope>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/com/codingame/game/Player.java
+++ b/src/main/java/com/codingame/game/Player.java
@@ -8,6 +8,7 @@ import com.codingame.gameengine.core.AbstractMultiplayerPlayer;
 // public class Player extends AbstractSoloPlayer {
 public class Player extends AbstractMultiplayerPlayer {
     private final Inventory inventory = new Inventory();
+    private Item offeredItem;
 
     @Override
     public int getExpectedOutputLines() {
@@ -25,6 +26,14 @@ public class Player extends AbstractMultiplayerPlayer {
 
     public boolean drop(Item item) {
         return inventory.drop(item);
+    }
+
+    public void setOfferedItem(Item item) {
+        this.offeredItem = item;
+    }
+
+    public Item getOfferedItem() {
+        return offeredItem;
     }
 
     public void modifyItem(Item item, int weight, int value, int quality) {

--- a/src/main/java/com/codingame/game/Referee.java
+++ b/src/main/java/com/codingame/game/Referee.java
@@ -1,11 +1,13 @@
 package com.codingame.game;
 import java.util.List;
+import java.util.Random;
 
 import com.codingame.gameengine.core.AbstractPlayer.TimeoutException;
 import com.codingame.gameengine.core.AbstractReferee;
 import com.codingame.gameengine.core.MultiplayerGameManager;
 import com.codingame.gameengine.module.entities.GraphicEntityModule;
 import com.google.inject.Inject;
+import com.codingame.game.model.Item;
 
 public class Referee extends AbstractReferee {
     // Uncomment the line below and comment the line under it to create a Solo Game
@@ -13,25 +15,48 @@ public class Referee extends AbstractReferee {
     @Inject private MultiplayerGameManager<Player> gameManager;
     @Inject private GraphicEntityModule graphicEntityModule;
 
+    private final Random random = new Random();
+
     @Override
     public void init() {
-        // Initialize your game here.
+        gameManager.setMaxTurns(5);
     }
 
     @Override
     public void gameTurn(int turn) {
         for (Player player : gameManager.getActivePlayers()) {
-            player.sendInputLine("input");
+            Item item = new Item("Item" + turn,
+                random.nextInt(3) + 1,
+                random.nextInt(5) + 1,
+                random.nextInt(5) + 1);
+            player.setOfferedItem(item);
+            player.sendInputLine(String.format("ITEM %s %d %d %d",
+                item.getName(), item.getWeight(), item.getValue(), item.getQuality()));
             player.execute();
         }
 
         for (Player player : gameManager.getActivePlayers()) {
             try {
                 List<String> outputs = player.getOutputs();
-                // Check validity of the player output and compute the new game state
+                if (!outputs.isEmpty()) {
+                    String out = outputs.get(0).trim();
+                    if ("PICK".equalsIgnoreCase(out)) {
+                        Item it = player.getOfferedItem();
+                        if (player.pickUp(it)) {
+                            player.setScore(player.getScore() + it.getValue());
+                        }
+                    } else if ("PASS".equalsIgnoreCase(out)) {
+                        // player chooses not to pick the offered item
+                    }
+                }
+                player.setOfferedItem(null);
             } catch (TimeoutException e) {
                 player.deactivate(String.format("$%d timeout!", player.getIndex()));
             }
-        }        
+        }
+
+        if (turn == gameManager.getMaxTurns() - 1) {
+            gameManager.endGame();
+        }
     }
 }

--- a/src/test/java/Agent1.java
+++ b/src/test/java/Agent1.java
@@ -3,10 +3,10 @@ import java.util.Scanner;
 public class Agent1 {
     public static void main(String[] args) {
         Scanner scanner = new Scanner(System.in);
-
-        while (true) {
+        while (scanner.hasNextLine()) {
             String input = scanner.nextLine();
-            System.out.println("my output");
+            System.out.println("PICK");
         }
+        scanner.close();
     }
 }

--- a/src/test/java/Agent2.java
+++ b/src/test/java/Agent2.java
@@ -1,13 +1,19 @@
-import java.util.Random;
 import java.util.Scanner;
+import java.util.Random;
 
 public class Agent2 {
     public static void main(String[] args) {
         Scanner scanner = new Scanner(System.in);
+        Random random = new Random();
 
-        while (true) {
+        while (scanner.hasNextLine()) {
             String input = scanner.nextLine();
-            System.out.println("my output");
+            if (random.nextBoolean()) {
+                System.out.println("PICK");
+            } else {
+                System.out.println("PASS");
+            }
         }
+        scanner.close();
     }
 }


### PR DESCRIPTION
## Summary
- implement a simple inventory-based prototype in `Referee`
- allow storing offered items in `Player`
- create simple agent behaviors
- include exec plugin and instructions for running on macOS
- handle pass actions and reset player offered item
- configure exec plugin

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6843938b282c83238ff5eab614cf8a10